### PR TITLE
Fix pytorch version to 1.4.0 to make sure dextr works without warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.7.12
 
 RUN apt-get update
 RUN apt-get install 'ffmpeg'\
@@ -9,7 +9,8 @@ RUN apt install -y liblzma-dev
 
 WORKDIR /workspace
 COPY requirements_container.txt /workspace
-RUN pip install numpy
+COPY torch-1.4.0+cpu-cp37-cp37m-linux_x86_64.whl /workspace
+#RUN pip install numpy
 RUN pip install -r requirements_container.txt
 RUN python -c "from dextr.model import DextrModel; DextrModel.pascalvoc_resunet101()"
 RUN pip install gunicorn==20.0.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,9 @@ RUN apt-get install 'ffmpeg'\
 RUN apt install -y liblzma-dev
 
 WORKDIR /workspace
+RUN wget https://download.pytorch.org/whl/cpu/torch-1.4.0%2Bcpu-cp37-cp37m-linux_x86_64.whl
 COPY requirements_container.txt /workspace
-COPY torch-1.4.0+cpu-cp37-cp37m-linux_x86_64.whl /workspace
+#COPY torch-1.4.0+cpu-cp37-cp37m-linux_x86_64.whl /workspace
 #RUN pip install numpy
 RUN pip install -r requirements_container.txt
 RUN python -c "from dextr.model import DextrModel; DextrModel.pascalvoc_resunet101()"

--- a/action-datatorch.yaml
+++ b/action-datatorch.yaml
@@ -20,7 +20,7 @@ inputs:
       port if not found.
   image:
     type: string
-    default: datatorch/action-dextr
+    default: add3000/dextr_test
     description: Docker image to spin up.
   annotationId:
     type: string

--- a/entry.py
+++ b/entry.py
@@ -154,7 +154,7 @@ def send_request():
                 break
             print(f"Attempt {attempts}: Could not connect to dextr.")
             start_server(address.port or 80)
-            time.sleep(5)
+            time.sleep(1500)
 
     print("Could not send request.")
     exit(1)

--- a/requirements_container.txt
+++ b/requirements_container.txt
@@ -19,15 +19,14 @@ Pillow==8.0.1
 pyparsing==2.4.7
 python-dateutil==2.8.1
 PyWavelets==1.1.1
-scikit-build==0.11.1
-scikit-image==0.17.2
 scipy==1.5.4
 six==1.15.0
 tifffile==2020.9.3
-torch==1.10.0
-torchvision
+torch-1.4.0+cpu-cp37-cp37m-linux_x86_64.whl
+torchvision==0.5.0
 typing-extensions==3.7.4.3
 Werkzeug==1.0.1
 xmljson==0.2.1
 imantics
-dextr @ git+https://github.com/ninthreezy/dextr@master
+scikit-image==0.19.1
+dextr @ git+https://github.com/aoxolotl/dextr@test_req


### PR DESCRIPTION
1. Switch container to docker version 3.7.12
2. Download torch file from old [pytotch versions page](https://download.pytorch.org/whl/torch_stable.html)
3. [Temp fix] Use dextr repo test branch which has better requirements versioning